### PR TITLE
feat: 添加select方法适配

### DIFF
--- a/harmony/picker/src/main/ets/Magic.ts
+++ b/harmony/picker/src/main/ets/Magic.ts
@@ -32,7 +32,7 @@ export interface FontStyle {
 }
 
 export interface GlobalDialogParam {
-  content: string;
+  selected: string | string[];
 }
 
 export interface ResultItem {

--- a/harmony/picker/src/main/ets/PickerBaseOperate.ets
+++ b/harmony/picker/src/main/ets/PickerBaseOperate.ets
@@ -25,7 +25,7 @@ import Logger from './Logger';
 export const TAG = "Picker";
 
 @Builder
-function buildGlobalDialogComponent() {
+function buildGlobalDialogComponent(params: Params) {
   Column() {
     Flex({ direction: FlexDirection.Row, justifyContent: FlexAlign.SpaceBetween, alignItems: ItemAlign.Center }) {
       Text(content.pickerCancelBtnText)
@@ -54,7 +54,7 @@ function buildGlobalDialogComponent() {
     .height(FIVE_PERCENT)
     .width(HUNDRED_PERCENT)
 
-    TextPicker({ range: content.pickerData, value: content.selectedValue })
+    TextPicker({ range: content.pickerData, value: params.selected })
       .onChange((value: string | string[]) => {
         changeSelect(value);
       })
@@ -107,6 +107,14 @@ let pickerCtx: TurboModuleContext;
 let uiContext: UIContext;
 let showPicker: boolean = false;
 
+class Params {
+  selected: string | string[] = '';
+
+  constructor(selected: string | string[]) {
+    this.selected = selected;
+  }
+}
+
 export class GlobalDialog {
   static contentNode: ComponentContent<GlobalDialogParam>;
   protected ctx: TurboModuleContext;
@@ -122,7 +130,8 @@ export class GlobalDialog {
 
   static show() {
     try {
-      GlobalDialog.contentNode = new ComponentContent(uiContext, wrapBuilder(buildGlobalDialogComponent));
+      GlobalDialog.contentNode =
+        new ComponentContent(uiContext, wrapBuilder(buildGlobalDialogComponent), new Params(content.selectedValue));
       const promptAction = uiContext.getPromptAction();
       promptAction.openCustomDialog(GlobalDialog.contentNode, {
         alignment: DialogAlignment.Bottom,
@@ -157,6 +166,11 @@ export class GlobalDialog {
 
   getContent(): initOptions {
     return content;
+  }
+
+  update(array: Array<string>) {
+    content.selectedValue = array;
+    GlobalDialog.contentNode.update(new Params(content.selectedValue));
   }
 
   processData(data: object[]): ResultItem[] {

--- a/harmony/picker/src/main/ets/PickerTurboModule.ets
+++ b/harmony/picker/src/main/ets/PickerTurboModule.ets
@@ -21,6 +21,7 @@ export class RNCPickerTurboModule extends TurboModule {
   }
 
   select(array: Array<string>) {
+    this.pickerBaseOperate?.update(array);
   }
 
   hide() {


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- close #9 添加select方法适配


## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

无

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)

